### PR TITLE
Remove singleton and revert documentation

### DIFF
--- a/adafruit_trellism4.py
+++ b/adafruit_trellism4.py
@@ -91,7 +91,9 @@ class _NeoPixelArray:
 
         .. code-block:: python
 
-            from adafruit_trellism4 import trellis
+            import adafruit_trellism4
+
+            trellis = adafruit_trellism4.TrellisM4Express()
 
             trellis.pixels.brightness = 0.3
 
@@ -112,7 +114,9 @@ class _NeoPixelArray:
 
         .. code-block:: python
 
-            from adafruit_trellism4 import trellis
+            import adafruit_trellism4
+
+            trellis = adafruit_trellism4.TrellisM4Express()
 
             trellis.pixels.fill((255, 0, 0))
 
@@ -127,7 +131,9 @@ class _NeoPixelArray:
 
         .. code-block:: python
 
-            from adafruit_trellism4 import trellis
+            import adafruit_trellism4
+
+            trellis = adafruit_trellism4.TrellisM4Express()
 
             for x in range(trellis.pixels.width):
                 for y in range(trellis.pixels.height):
@@ -141,7 +147,9 @@ class _NeoPixelArray:
 
         .. code-block:: python
 
-            from adafruit_trellism4 import trellis
+            import adafruit_trellism4
+
+            trellis = adafruit_trellism4.TrellisM4Express()
 
             for x in range(trellis.pixels.width):
                 for y in range(trellis.pixels.height):
@@ -162,7 +170,9 @@ class TrellisM4Express:
     .. code-block:: python
 
          import time
-         from adafruit_trellism4 import trellis
+         import adafruit_trellism4
+
+         trellis = adafruit_trellism4.TrellisM4Express()
 
          current_press = set()
          while True:
@@ -190,7 +200,9 @@ class TrellisM4Express:
 
         .. code-block:: python
 
-            from adafruit_trellism4 import trellis
+            import adafruit_trellism4
+
+            trellis = adafruit_trellism4.TrellisM4Express()
 
             trellis.pixels[0, 0] = (0, 255, 0)
 
@@ -203,7 +215,9 @@ class TrellisM4Express:
 
             .. code-block:: python
 
-                from adafruit_trellism4 import trellis
+                import adafruit_trellism4
+
+                trellis = adafruit_trellism4.TrellisM4Express()
 
                 trellis.pixels.fill((255, 0, 0))
 
@@ -214,7 +228,9 @@ class TrellisM4Express:
 
             .. code-block:: python
 
-                from adafruit_trellism4 import trellis
+                import adafruit_trellism4
+
+                trellis = adafruit_trellism4.TrellisM4Express()
 
                 for x in range(trellis.pixels.width):
                     for y in range(trellis.pixels.height):
@@ -227,7 +243,9 @@ class TrellisM4Express:
 
             .. code-block:: python
 
-                from adafruit_trellism4 import trellis
+                import adafruit_trellism4
+
+                trellis = adafruit_trellism4.TrellisM4Express()
 
                 trellis.pixels.brightness = 0.3
 
@@ -268,7 +286,9 @@ class TrellisM4Express:
         .. code-block:: python
 
             import time
-            from adafruit_trellism4 import trellis
+            import adafruit_trellism4
+
+            trellis = adafruit_trellism4.TrellisM4Express()
 
             current_press = set()
             while True:
@@ -291,23 +311,14 @@ class TrellisM4Express:
 
         .. code-block:: python
 
-          import time
-          from adafruit_trellism4 import trellis
+            import time
+            import adafruit_trellism4
 
-          while True:
-              x, y, z = trellis.acceleration
-              print(x, y, z)
-              time.sleep(0.1)
+            trellis = adafruit_trellism4.TrellisM4Express()
+
+            while True:
+                x, y, z = trellis.acceleration
+                print(x, y, z)
+                time.sleep(0.1)
         """
         return self._adxl345.acceleration
-
-
-trellis = TrellisM4Express()  # pylint: disable=invalid-name
-"""Object that is automatically created on import.
-
-   To use, simply import it from the module:
-
-   .. code-block:: python
-
-       from adafruit_trellism4 import trellis
-"""

--- a/examples/neopixel_trellism4.simpletest.py
+++ b/examples/neopixel_trellism4.simpletest.py
@@ -1,7 +1,9 @@
 """Test your Trellis M4 Express without needing the serial output.
 Press any button and the rest will light up the same color!"""
 import time
-from adafruit_trellism4 import trellis
+import adafruit_trellism4
+
+trellis = adafruit_trellism4.TrellisM4Express()
 
 
 def wheel(pos):

--- a/examples/trellism4_press_and_release.py
+++ b/examples/trellism4_press_and_release.py
@@ -1,5 +1,7 @@
 import time
-from adafruit_trellism4 import trellis
+import adafruit_trellism4
+
+trellis = adafruit_trellism4.TrellisM4Express()
 
 current_press = set()
 while True:

--- a/examples/trellism4_simpletest.py
+++ b/examples/trellism4_simpletest.py
@@ -1,4 +1,6 @@
-from adafruit_trellism4 import trellis
+import adafruit_trellism4
+
+trellis = adafruit_trellism4.TrellisM4Express()
 
 while True:
     pressed = trellis.pressed_keys


### PR DESCRIPTION
The singleton import method eliminated access to setting rotation. Removed the singleton, and reverted all of the documetation and examples to the original import method to match.